### PR TITLE
refactor: remove misleading logs regarding SMTP

### DIFF
--- a/internal/pkg/email/pipeline.go
+++ b/internal/pkg/email/pipeline.go
@@ -137,8 +137,6 @@ func (p *PipelineDefault) Start(processor Processor) error {
 				zap.String("mailbox", cfg.IMAPMailbox),
 				zap.Int("poll_interval_seconds", cfg.PollInterval))
 		} else {
-			// Legacy SMTP server configuration - not used anymore
-			p.logger.Warn("SMTP server mode is deprecated. Please configure IMAP settings for email receiving.")
 			p.logger.Info("Email receiving is disabled")
 		}
 	} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed a warning message related to legacy SMTP server mode deprecation when IMAP settings are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->