### PR TITLE
fix: ensure subject is set for non-ARF emails in pipeline

### DIFF
--- a/internal/pkg/email/pipeline.go
+++ b/internal/pkg/email/pipeline.go
@@ -259,6 +259,13 @@ func (p *PipelineDefault) ProcessEmail(ctx context.Context, data io.Reader) (*Pr
 	if threadMatch == nil {
 		// ClassifyEmail content only when needed
 		classify := p.classifier.ClassifyEmail(parsedEmail)
+		
+		// Get subject from email headers
+		subject := parsedEmail.Headers.Subject
+		if subject == "" {
+			subject = "(no subject)"
+		}
+
 		// Get first 200 characters of email text as description
 		description := parsedEmail.Text
 		if len(description) > 200 {
@@ -269,7 +276,7 @@ func (p *PipelineDefault) ProcessEmail(ctx context.Context, data io.Reader) (*Pr
 			Type:        classify.CaseType,
 			Status:      models.CaseStatusNew,
 			Priority:    classify.Priority,
-			Description: fmt.Sprintf("Email Subject: %s\nContent: %s", parsedEmail.Headers.Subject, description),
+			Description: fmt.Sprintf("Email Subject: %s\nContent: %s", subject, description),
 			Source:      models.ReportSourceEmail,
 		}
 		p.metrics.mutex.Lock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of emails with missing subjects by displaying "(no subject)" when the subject is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->