### PR TITLE
refactor(email): restructure case creation to handle multiple subjects

### DIFF
--- a/internal/service/case.go
+++ b/internal/service/case.go
@@ -194,31 +194,6 @@ func (s *CaseServiceDefault) SendCreationNotification(caseID uint) error {
 	return nil
 }
 
-// LinkSubject associates a subject with a case
-func (s *CaseServiceDefault) LinkSubject(caseID, subjectID uint) error {
-	_, err := s.GetByID(caseID)
-	if err != nil {
-		return fmt.Errorf("failed to get case: %w", err)
-	}
-
-	// Create association through CaseScan model
-	scan := &models.CaseScan{
-		CaseID:    caseID,
-		SubjectID: subjectID,
-		Status:    models.ScanStatusPending,
-	}
-
-	if err := db.Create(context.Background(), s.ctx, s.db, scan); err != nil {
-		s.logger.Error("Failed to link subject to case",
-			zap.Uint("case_id", caseID),
-			zap.Uint("subject_id", subjectID),
-			zap.Error(err))
-		return fmt.Errorf("failed to link subject: %w", err)
-	}
-
-	return nil
-}
-
 // SendStatusUpdateNotification sends an email notification when a case status is updated
 func (s *CaseServiceDefault) SendStatusUpdateNotification(caseID uint, oldStatus, newStatus models.CaseStatus) error {
 	// Get the case

--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -306,15 +306,20 @@ func (s *EmailServiceDefault) handleARFReport(arfData *email.ARFReport, caseMode
 		}
 	}
 
-	// Update case model with pipeline-generated data
-	caseModel.ReporterID = reporter.ID
-	caseModel.Type = s.determineCaseType(arfData.FeedbackType)
-	caseModel.Status = models.CaseStatusNew
-	caseModel.Source = models.ReportSourceEmail
-	caseModel.Description = arfData.FeedbackText
-	caseModel.Priority = s.determinePriority(arfData)
+	// Extract subjects first
+	urlSubjectIDs, err := s.extractAndLinkURLSubjects(arfData.FeedbackText)
+	if err != nil {
+		return fmt.Errorf("error extracting URL subjects: %w", err)
+	}
 
-	// Check if reporter is trusted
+	hashSubjectIDs, err := s.extractAndLinkHashSubjects(arfData.FeedbackText)
+	if err != nil {
+		return fmt.Errorf("error extracting hash subjects: %w", err)
+	}
+
+	allSubjectIDs := append(urlSubjectIDs, hashSubjectIDs...)
+
+	// Check reporter trust status once before the loop
 	isTrusted, err := s.reporterSvc.IsTrusted(reporter)
 	if err != nil {
 		s.logger.Error("Failed to check reporter trust status",
@@ -323,17 +328,27 @@ func (s *EmailServiceDefault) handleARFReport(arfData *email.ARFReport, caseMode
 		return fmt.Errorf("failed to check reporter trust status: %w", err)
 	}
 
-	// Only needs review if reporter is not trusted
-	caseModel.NeedsReview = !isTrusted
+	// Create cases for each subject
+	for _, subjectID := range allSubjectIDs {
+		// Create a new case model copy for each subject
+		caseCopy := *caseModel
+		caseCopy.ReporterID = reporter.ID
+		caseCopy.Type = s.determineCaseType(arfData.FeedbackType)
+		caseCopy.Status = models.CaseStatusNew
+		caseCopy.Source = models.ReportSourceEmail
+		caseCopy.Description = arfData.FeedbackText
+		caseCopy.Priority = s.determinePriority(arfData)
+		caseCopy.SubjectID = subjectID
+		caseCopy.NeedsReview = !isTrusted // Use pre-checked trust status
 
-	createdCase, err := s.caseSvc.Create(caseModel)
-	if err != nil {
-		s.logger.Error("Failed to create case", zap.Error(err))
-		return db.HandleDBError(err, "Create", "Case", 0)
-	}
+		createdCase, err := s.caseSvc.Create(&caseCopy)
+		if err != nil {
+			s.logger.Error("Failed to create case", zap.Error(err))
+			return db.HandleDBError(err, "Create", "Case", 0)
+		}
 
-	// Create communication record
-	arfDetails := fmt.Sprintf(`
+		// Create communication record
+		arfDetails := fmt.Sprintf(`
 ARF Report Details:
 -------------------
 Feedback Type: %s
@@ -351,71 +366,84 @@ Machine Readable Data:
 Feedback Text:
 %s
 `,
-		arfData.FeedbackType,
-		arfData.SourceIP,
-		arfData.UserAgent,
-		arfData.ArrivalDate,
-		arfData.OriginalFrom,
-		arfData.OriginalRecipient,
-		arfData.OriginalSubject,
-		s.formatMachineReadable(arfData.MachineReadable),
-		arfData.FeedbackText,
-	)
+			arfData.FeedbackType,
+			arfData.SourceIP,
+			arfData.UserAgent,
+			arfData.ArrivalDate,
+			arfData.OriginalFrom,
+			arfData.OriginalRecipient,
+			arfData.OriginalSubject,
+			s.formatMachineReadable(arfData.MachineReadable),
+			arfData.FeedbackText,
+		)
 
-	comm := &models.Communication{
-		CaseID:    createdCase.ID,
-		SenderID:  reporter.ID,
-		Type:      models.CommunicationTypeEmail,
-		Direction: models.CommunicationDirectionExternal,
-		Content:   arfDetails,
-		ThreadID:  fmt.Sprintf("ARF-REPORT-%d@system", createdCase.ID),
+		comm := &models.Communication{
+			CaseID:    createdCase.ID,
+			SenderID:  reporter.ID,
+			Type:      models.CommunicationTypeEmail,
+			Direction: models.CommunicationDirectionExternal,
+			Content:   arfDetails,
+			ThreadID:  fmt.Sprintf("ARF-REPORT-%d@system", createdCase.ID),
+		}
+
+		if _, err := s.commSvc.Create(comm); err != nil {
+			return db.HandleDBError(err, "handleThreadMatch", "Communication", 0)
+		}
+
+		s.logger.Info("Successfully processed ARF report",
+			zap.String("feedback_type", arfData.FeedbackType),
+			zap.String("case_ref", createdCase.ReferenceNumber),
+			zap.Uint("case_id", createdCase.ID))
 	}
-
-	if _, err := s.commSvc.Create(comm); err != nil {
-		return db.HandleDBError(err, "handleThreadMatch", "Communication", 0)
-	}
-
-	// Extract and link subjects from ARF report content
-	s.extractAndLinkURLSubjects(createdCase.ID, arfData.FeedbackText)
-	s.extractAndLinkHashSubjects(createdCase.ID, arfData.FeedbackText)
-
-	s.logger.Info("Successfully processed ARF report",
-		zap.String("feedback_type", arfData.FeedbackType),
-		zap.String("case_ref", createdCase.ReferenceNumber),
-		zap.Uint("case_id", createdCase.ID))
 
 	return nil
 }
 
 func (s *EmailServiceDefault) handleNewCase(caseModel *models.Case, email *letters.Email) error {
-	// Create the case
-	createdCase, err := s.caseSvc.Create(caseModel)
+	// Extract subjects first
+	urlSubjectIDs, err := s.extractAndLinkURLSubjects(email.Text)
 	if err != nil {
-		return fmt.Errorf("failed to create case: %w", err)
+		return fmt.Errorf("error extracting URL subjects: %w", err)
 	}
 
-	// Create communication record
-	comm := &models.Communication{
-		CaseID:    createdCase.ID,
-		SenderID:  caseModel.ReporterID,
-		Type:      models.CommunicationTypeEmail,
-		Direction: models.CommunicationDirectionExternal,
-		Content:   email.Text,
-		ThreadID:  string(email.Headers.MessageID),
+	hashSubjectIDs, err := s.extractAndLinkHashSubjects(email.Text)
+	if err != nil {
+		return fmt.Errorf("error extracting hash subjects: %w", err)
 	}
 
-	if _, err := s.commSvc.Create(comm); err != nil {
-		return fmt.Errorf("failed to create communication: %w", err)
+	allSubjectIDs := append(urlSubjectIDs, hashSubjectIDs...)
+
+	// Create cases for each subject
+	for _, subjectID := range allSubjectIDs {
+		// Create a new case model copy for each subject
+		caseCopy := *caseModel
+		caseCopy.SubjectID = subjectID
+
+		// Create the case
+		createdCase, err := s.caseSvc.Create(&caseCopy)
+		if err != nil {
+			return fmt.Errorf("failed to create case: %w", err)
+		}
+
+		// Create communication record
+		comm := &models.Communication{
+			CaseID:    createdCase.ID,
+			SenderID:  caseModel.ReporterID,
+			Type:      models.CommunicationTypeEmail,
+			Direction: models.CommunicationDirectionExternal,
+			Content:   email.Text,
+			ThreadID:  string(email.Headers.MessageID),
+		}
+
+		if _, err := s.commSvc.Create(comm); err != nil {
+			return fmt.Errorf("failed to create communication: %w", err)
+		}
+
+		s.logger.Info("Successfully processed new case",
+			zap.String("case_ref", createdCase.ReferenceNumber),
+			zap.Uint("case_id", createdCase.ID),
+			zap.String("source", string(createdCase.Source)))
 	}
-
-	// Extract and link subjects from email content
-	s.extractAndLinkURLSubjects(createdCase.ID, email.Text)
-	s.extractAndLinkHashSubjects(createdCase.ID, email.Text)
-
-	s.logger.Info("Successfully processed new case",
-		zap.String("case_ref", createdCase.ReferenceNumber),
-		zap.Uint("case_id", createdCase.ID),
-		zap.String("source", string(createdCase.Source)))
 
 	return nil
 }
@@ -549,65 +577,6 @@ func (s *EmailServiceDefault) formatMachineReadable(fields map[string]string) st
 	return result.String()
 }
 
-// extractAndCreateSubjects extracts and creates subjects from an ARF report
-func (s *EmailServiceDefault) extractAndCreateSubjects(caseID uint, report *email.ARFReport) {
-	if s.subjectSvc == nil {
-		s.logger.Error("Subject service not available")
-		return
-	}
-
-	// Create a temporary email structure for content extraction
-	feedbackEmail := &letters.Email{
-		Text: report.FeedbackText,
-	}
-
-	// Extract URLs from feedback text
-	contentExtractor := email.NewContentExtractor(s.logger)
-	urls := contentExtractor.ExtractURLs(feedbackEmail)
-	for _, url := range urls {
-		subject, err := s.subjectSvc.FindOrCreateByURL(url, models.SubjectTypeURL)
-		if err != nil {
-			s.logger.Error("Failed to create subject from URL in feedback text",
-				zap.Error(err),
-				zap.String("url", url))
-			continue
-		}
-
-		// Link subject to case
-		if err := s.caseSvc.LinkSubject(caseID, subject.ID); err != nil {
-			s.logger.Error("Failed to link subject to case",
-				zap.Uint("case_id", caseID),
-				zap.Uint("subject_id", subject.ID),
-				zap.Error(err))
-		}
-	}
-
-	// Extract hashes from feedback text
-	hashes := contentExtractor.ExtractHashes(feedbackEmail)
-	for _, hash := range hashes {
-		sHash, err := core.ParseStorageHash(hash)
-		if err != nil {
-			s.logger.Error("Failed to create storage hash hash in feedback text",
-				zap.Error(err),
-				zap.String("hash", hash))
-		}
-		subject, err := s.subjectSvc.FindOrCreate(sHash, models.SubjectTypeHash)
-		if err != nil {
-			s.logger.Error("Failed to create subject from hash in feedback text",
-				zap.Error(err),
-				zap.String("hash", hash))
-			continue
-		}
-
-		// Link subject to case
-		if err := s.caseSvc.LinkSubject(caseID, subject.ID); err != nil {
-			s.logger.Error("Failed to link subject to case",
-				zap.Uint("case_id", caseID),
-				zap.Uint("subject_id", subject.ID),
-				zap.Error(err))
-		}
-	}
-}
 func (s *EmailServiceDefault) GenerateCaseThreadID(referenceNumber string) string {
 	domain := s.ctx.Config().Config().Core.Domain
 	return fmt.Sprintf("<case.%s.%s@%s>", referenceNumber, s.ctx.Config().Config().Core.PortalName, domain)
@@ -687,10 +656,10 @@ func (s *EmailServiceDefault) hashEmailContent(email *letters.Email) ([]byte, er
 }
 
 // extractAndLinkURLSubjects extracts URLs from email content and links them to case
-func (s *EmailServiceDefault) extractAndLinkURLSubjects(caseID uint, emailContent string) {
+func (s *EmailServiceDefault) extractAndLinkURLSubjects(emailContent string) ([]uint, error) {
 	if s.subjectSvc == nil {
 		s.logger.Error("Subject service not available")
-		return
+		return nil, fmt.Errorf("subject service not available")
 	}
 
 	// Create temporary email structure for content extraction
@@ -701,29 +670,28 @@ func (s *EmailServiceDefault) extractAndLinkURLSubjects(caseID uint, emailConten
 	// Extract URLs
 	contentExtractor := email.NewContentExtractor(s.logger)
 	urls := contentExtractor.ExtractURLs(feedbackEmail)
+
+	subjectIDs := make([]uint, 0, len(urls)) // Pre-allocate slice
+
 	for _, url := range urls {
 		subject, err := s.subjectSvc.FindOrCreateByURL(url, models.SubjectTypeURL)
 		if err != nil {
 			s.logger.Error("Failed to create subject from URL",
 				zap.Error(err),
 				zap.String("url", url))
-			continue
+			return nil, fmt.Errorf("failed to create subject from URL: %w", err)
 		}
-
-		if err := s.caseSvc.LinkSubject(caseID, subject.ID); err != nil {
-			s.logger.Error("Failed to link subject to case",
-				zap.Uint("case_id", caseID),
-				zap.Uint("subject_id", subject.ID),
-				zap.Error(err))
-		}
+		subjectIDs = append(subjectIDs, subject.ID)
 	}
+
+	return subjectIDs, nil
 }
 
 // extractAndLinkHashSubjects extracts hashes from email content and links them to case
-func (s *EmailServiceDefault) extractAndLinkHashSubjects(caseID uint, emailContent string) {
+func (s *EmailServiceDefault) extractAndLinkHashSubjects(emailContent string) ([]uint, error) {
 	if s.subjectSvc == nil {
 		s.logger.Error("Subject service not available")
-		return
+		return nil, fmt.Errorf("subject service not available")
 	}
 
 	// Create temporary email structure for content extraction
@@ -734,13 +702,16 @@ func (s *EmailServiceDefault) extractAndLinkHashSubjects(caseID uint, emailConte
 	// Extract hashes
 	contentExtractor := email.NewContentExtractor(s.logger)
 	hashes := contentExtractor.ExtractHashes(feedbackEmail)
+
+	subjectIDs := make([]uint, 0, len(hashes)) // Pre-allocate slice
+
 	for _, hash := range hashes {
 		sHash, err := core.ParseStorageHash(hash)
 		if err != nil {
 			s.logger.Error("Failed to parse hash",
 				zap.Error(err),
 				zap.String("hash", hash))
-			continue
+			return nil, fmt.Errorf("failed to parse hash: %w", err)
 		}
 
 		subject, err := s.subjectSvc.FindOrCreate(sHash, models.SubjectTypeHash)
@@ -748,14 +719,10 @@ func (s *EmailServiceDefault) extractAndLinkHashSubjects(caseID uint, emailConte
 			s.logger.Error("Failed to create subject from hash",
 				zap.Error(err),
 				zap.String("hash", hash))
-			continue
+			return nil, fmt.Errorf("failed to create subject from hash: %w", err)
 		}
-
-		if err := s.caseSvc.LinkSubject(caseID, subject.ID); err != nil {
-			s.logger.Error("Failed to link subject to case",
-				zap.Uint("case_id", caseID),
-				zap.Uint("subject_id", subject.ID),
-				zap.Error(err))
-		}
+		subjectIDs = append(subjectIDs, subject.ID)
 	}
+
+	return subjectIDs, nil
 }

--- a/internal/service/mocks/CaseService.go
+++ b/internal/service/mocks/CaseService.go
@@ -769,63 +769,6 @@ func (_c *MockCaseService_ID_Call) RunAndReturn(run func() string) *MockCaseServ
 	return _c
 }
 
-// LinkSubject provides a mock function for the type MockCaseService
-func (_mock *MockCaseService) LinkSubject(caseID uint, subjectID uint) error {
-	ret := _mock.Called(caseID, subjectID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for LinkSubject")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(uint, uint) error); ok {
-		r0 = returnFunc(caseID, subjectID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockCaseService_LinkSubject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LinkSubject'
-type MockCaseService_LinkSubject_Call struct {
-	*mock.Call
-}
-
-// LinkSubject is a helper method to define mock.On call
-//   - caseID uint
-//   - subjectID uint
-func (_e *MockCaseService_Expecter) LinkSubject(caseID interface{}, subjectID interface{}) *MockCaseService_LinkSubject_Call {
-	return &MockCaseService_LinkSubject_Call{Call: _e.mock.On("LinkSubject", caseID, subjectID)}
-}
-
-func (_c *MockCaseService_LinkSubject_Call) Run(run func(caseID uint, subjectID uint)) *MockCaseService_LinkSubject_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 uint
-		if args[0] != nil {
-			arg0 = args[0].(uint)
-		}
-		var arg1 uint
-		if args[1] != nil {
-			arg1 = args[1].(uint)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockCaseService_LinkSubject_Call) Return(err error) *MockCaseService_LinkSubject_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockCaseService_LinkSubject_Call) RunAndReturn(run func(caseID uint, subjectID uint) error) *MockCaseService_LinkSubject_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // List provides a mock function for the type MockCaseService
 func (_mock *MockCaseService) List(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]models.Case, int64, error) {
 	ret := _mock.Called(filters, sorts, pagination)

--- a/internal/service/mocks/EmailService.go
+++ b/internal/service/mocks/EmailService.go
@@ -250,6 +250,57 @@ func (_c *MockEmailService_IsEmailProcessed_Call) RunAndReturn(run func(email *l
 	return _c
 }
 
+// MarkEmailProcessed provides a mock function for the type MockEmailService
+func (_mock *MockEmailService) MarkEmailProcessed(email *letters.Email) error {
+	ret := _mock.Called(email)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkEmailProcessed")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(*letters.Email) error); ok {
+		r0 = returnFunc(email)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockEmailService_MarkEmailProcessed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkEmailProcessed'
+type MockEmailService_MarkEmailProcessed_Call struct {
+	*mock.Call
+}
+
+// MarkEmailProcessed is a helper method to define mock.On call
+//   - email *letters.Email
+func (_e *MockEmailService_Expecter) MarkEmailProcessed(email interface{}) *MockEmailService_MarkEmailProcessed_Call {
+	return &MockEmailService_MarkEmailProcessed_Call{Call: _e.mock.On("MarkEmailProcessed", email)}
+}
+
+func (_c *MockEmailService_MarkEmailProcessed_Call) Run(run func(email *letters.Email)) *MockEmailService_MarkEmailProcessed_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 *letters.Email
+		if args[0] != nil {
+			arg0 = args[0].(*letters.Email)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockEmailService_MarkEmailProcessed_Call) Return(err error) *MockEmailService_MarkEmailProcessed_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockEmailService_MarkEmailProcessed_Call) RunAndReturn(run func(email *letters.Email) error) *MockEmailService_MarkEmailProcessed_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ProcessIncomingEmail provides a mock function for the type MockEmailService
 func (_mock *MockEmailService) ProcessIncomingEmail(ctx context.Context, rawEmail io.Reader) error {
 	ret := _mock.Called(ctx, rawEmail)

--- a/internal/types/service/case_service.go
+++ b/internal/types/service/case_service.go
@@ -116,9 +116,6 @@ type CaseService interface {
 	// Search performs a more advanced search on cases
 	Search(ctx context.Context, query string, filters []queryutil.CrudFilter, pagination queryutil.Pagination) ([]models.Case, int64, error)
 
-	// LinkSubject associates a subject with a case
-	LinkSubject(caseID, subjectID uint) error
-
 	// SendCreationNotification sends an email notification when a case is created
 	SendCreationNotification(caseID uint) error
 


### PR DESCRIPTION
- Removed LinkSubject method from CaseService interface and implementation
- Modified email handling to:
  * Extract subjects before case creation
  * Create separate cases for each subject found
  * Return subject IDs from extractAndLinkURL/Subjects functions
- Simplified subject linking by including SubjectID directly in case creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for marking emails as processed.

* **Bug Fixes**
  * Improved handling of subjects in email reports, now creating separate cases for each extracted subject.

* **Refactor**
  * Streamlined subject extraction and case creation from emails for better error handling and clarity.
  * Removed deprecated subject linking method from case management.

* **Tests**
  * Updated test mocks to reflect changes in subject linking and email processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->