### PR TITLE
refactor(db): use gorm.ErrRecordNotFound directly instead of custom error

### DIFF
--- a/internal/db/crud.go
+++ b/internal/db/crud.go
@@ -17,7 +17,7 @@ import (
 
 // Database error types
 var (
-	ErrRecordNotFound      = errors.New("record not found")
+	ErrRecordNotFound      = gorm.ErrRecordNotFound
 	ErrDuplicateEntry      = errors.New("duplicate entry")
 	ErrConstraintViolation = errors.New("constraint violation")
 	ErrTransactionFailed   = errors.New("transaction failed")

--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -119,8 +119,8 @@ func (s *EmailServiceDefault) getOrCreateReporter(email string, name string) (*m
 		return reporter, nil
 	}
 
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		s.logger.Error("Failed to get reporter by email", 
+	if !errors.Is(err, db.ErrRecordNotFound) {
+		s.logger.Error("Failed to get reporter by email",
 			zap.Error(err),
 			zap.String("email", email))
 		return nil, db.HandleDBError(err, "GetByEmail", "Reporter", 0)


### PR DESCRIPTION
- Changed ErrRecordNotFound to use gorm.ErrRecordNotFound directly
- Updated email service to check for db.ErrRecordNotFound instead of gorm.ErrRecordNotFound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in error handling for record-not-found cases by aligning error variables with standard library usage. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->