### PR TITLE
refactor(db): remove unneeded content hash column

### DIFF
--- a/internal/db/migrations/mysql/20250717212634_initial_schema.sql
+++ b/internal/db/migrations/mysql/20250717212634_initial_schema.sql
@@ -42,7 +42,6 @@ CREATE TABLE IF NOT EXISTS abuse_cases (
     source ENUM('web_form', 'email', 'api') NOT NULL,
     is_duplicate BOOLEAN DEFAULT FALSE,
     needs_review BOOLEAN DEFAULT FALSE,
-    content_hash VARCHAR(255) NOT NULL,
     classification_scores JSON,
     risk_factors JSON,
     reporter_id INT NOT NULL,

--- a/internal/db/migrations/sqlite/20250717212634_initial_schema.sql
+++ b/internal/db/migrations/sqlite/20250717212634_initial_schema.sql
@@ -52,7 +52,6 @@ create table if not exists abuse_cases (
     source TEXT check (source in ('web_form', 'email', 'api')) not null,
     is_duplicate BOOLEAN default FALSE,
     needs_review BOOLEAN default FALSE,
-    content_hash TEXT not null,
     classification_scores TEXT,
     risk_factors TEXT,
     reporter_id INTEGER not null,

--- a/internal/db/models/case.go
+++ b/internal/db/models/case.go
@@ -69,10 +69,6 @@ type Case struct {
 
 	// Review flag
 	NeedsReview bool
-
-	// Content hash for tracking
-	ContentHash string
-
 	// Classification metadata - stored as JSON
 	ClassificationScores datatypes.JSON `gorm:"type:json"`
 	RiskFactors          datatypes.JSON `gorm:"type:json"`

--- a/internal/service/communication_test.go
+++ b/internal/service/communication_test.go
@@ -44,7 +44,6 @@ func TestCommunicationService_Create(t *testing.T) {
 			Source:          models.ReportSourceWebForm,
 			ReporterID:      reporterID,
 			SubjectID:       1, // Must match the subject created below
-			ContentHash:     "testhash",
 		}
 
 		reporter := &models.Reporter{

--- a/internal/service/evidence_test.go
+++ b/internal/service/evidence_test.go
@@ -71,7 +71,6 @@ func TestEvidenceService_CreateFromData(t *testing.T) {
 			Source:          models.ReportSourceWebForm,
 			ReporterID:      1,
 			SubjectID:       1, // Must match the subject created below
-			ContentHash:     "testhash",
 		}
 
 		mockReporter := &models.Reporter{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the content hash field from abuse case records. This affects how abuse case data is stored and displayed.

* **Tests**
  * Updated related tests to reflect the removal of the content hash field from abuse case data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->