### PR TITLE
feat(blocklist): add subject blocked status check endpoint

### DIFF
--- a/internal/api/admin_extension_blocklist.go
+++ b/internal/api/admin_extension_blocklist.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"net/http"
+	"strconv"
 )
 
 // registerBlockListHandlers registers the block list related route handlers using portal-router.
@@ -84,6 +85,28 @@ func (e *AdminExtension) registerBlockListHandlers(gRouter router.Router, access
 					router.DefineSwaggerErrorResponses(
 						router.DefineSwaggerErrorResponse(http.StatusBadRequest, "Invalid hash format"),
 						router.DefineSwaggerErrorResponse(http.StatusNotFound, "Blocked content not found"),
+					),
+				),
+			),
+		),
+
+		// Check if subject is blocked
+		router.NewRoute(http.MethodGet, "/blocklist/subjects/:subject_id/blocked", e.checkSubjectBlocked,
+			router.WithAccess(core.ACCESS_ADMIN_ROLE),
+			router.WithSwagger(
+				router.WithSummary("Check subject blocked status"),
+				router.WithDescription("Check if a subject ID is blocked"),
+				router.WithTags("Blocklist"),
+				router.WithPathParam("subject_id", "ID of the subject to check", "123"),
+				router.WithSuccessResponse(
+					http.StatusOK,
+					"Subject blocked status",
+					router.WithJSONContent(dto.SubjectBlockedResponse{}),
+				),
+				router.WithErrorResponses(
+					router.DefineSwaggerErrorResponses(
+						router.DefineSwaggerErrorResponse(http.StatusBadRequest, "Invalid subject_id format"),
+						router.DefineSwaggerErrorResponse(http.StatusInternalServerError, "Failed to check block status"),
 					),
 				),
 			),
@@ -227,6 +250,36 @@ func (e *AdminExtension) getBlockedContent(c echo.Context) error { // Changed si
 	}
 
 	return nil // Return nil on success
+}
+
+// checkSubjectBlocked checks if a subject ID is blocked
+func (e *AdminExtension) checkSubjectBlocked(c echo.Context) error {
+	ctx := httputil.Context(c)
+
+	if e.blockListService == nil {
+		e.logger.Error("Blocklist service not available")
+		return ctx.Error(errors.New("service unavailable"), http.StatusInternalServerError)
+	}
+
+	subjectIDStr := c.Param("subject_id")
+	subjectID, err := strconv.ParseUint(subjectIDStr, 10, 32)
+	if err != nil {
+		return ctx.Error(fmt.Errorf("invalid subject_id format"), http.StatusBadRequest)
+	}
+
+	isBlocked, err := e.blockListService.IsSubjectBlocked(uint(subjectID))
+	if err != nil {
+		e.logger.Error("Failed to check subject block status", zap.Error(err))
+		return ctx.Error(fmt.Errorf("failed to check block status"), http.StatusInternalServerError)
+	}
+
+	var responseDto dto.SubjectBlockedResponse
+
+	if err := httputil.EncodeResponse[bool, *dto.SubjectBlockedResponse](ctx, isBlocked, &responseDto); err != nil { // Use httputil.EncodeResponse
+		e.logger.Error("Failed to encode response", zap.Error(err))
+		return err // httputil.EncodeResponse returns an error
+	}
+	return nil
 }
 
 // unblockContent handles DELETE requests to remove content from the block list

--- a/internal/api/admin_extension_blocklist_test.go
+++ b/internal/api/admin_extension_blocklist_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -173,6 +174,59 @@ func TestListBlocks_Success(t *testing.T) {
 		assert.NoError(tb, err)
 		assert.Len(tb, response.Data, 2)
 		assert.Equal(tb, models.BlockReasonMalware, response.Data[0].Reason)
+	})
+}
+
+func TestCheckSubjectBlocked_Success(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		mockBlocklistSvc := core.GetService[*mocks.MockBlockListService](ctx, service.BLOCKLIST_SERVICE)
+		assert.NotNil(tb, mockBlocklistSvc)
+
+		mockBlocklistSvc.EXPECT().IsSubjectBlocked(uint(123)).Return(true, nil).Once()
+
+		// Act
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/abuse/blocklist/subjects/123/blocked", nil)
+		w := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(w, req)
+
+		// Assert
+		assert.Equal(tb, http.StatusOK, w.Code)
+
+		var response dto.SubjectBlockedResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(tb, err)
+		assert.True(tb, response.Blocked)
+	})
+}
+
+func TestCheckSubjectBlocked_InvalidID(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Act
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/abuse/blocklist/subjects/invalid/blocked", nil)
+		w := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(w, req)
+
+		// Assert
+		assert.Equal(tb, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestCheckSubjectBlocked_ServiceError(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		mockBlocklistSvc := core.GetService[*mocks.MockBlockListService](ctx, service.BLOCKLIST_SERVICE)
+		assert.NotNil(tb, mockBlocklistSvc)
+
+		mockBlocklistSvc.EXPECT().IsSubjectBlocked(uint(123)).Return(false, errors.New("service error")).Once()
+
+		// Act
+		req := ctx.NewAPIRequest(http.MethodGet, "/api/abuse/blocklist/subjects/123/blocked", nil)
+		w := httptest.NewRecorder()
+		ctx.Router().ServeHTTP(w, req)
+
+		// Assert
+		assert.Equal(tb, http.StatusInternalServerError, w.Code)
 	})
 }
 

--- a/internal/api/dto/blocklist.go
+++ b/internal/api/dto/blocklist.go
@@ -16,6 +16,7 @@ var _ httputil.DTOValidator = (*BlockContentUpdateRequest)(nil)
 var _ httputil.DTORequest[*models.BlockList] = (*BlockContentCreateRequest)(nil)
 var _ httputil.DTORequest[*models.BlockList] = (*BlockContentUpdateRequest)(nil)
 var _ httputil.DTOResponse[*models.BlockList] = (*BlockContentResponse)(nil)
+var _ httputil.DTOResponse[bool] = (*SubjectBlockedResponse)(nil)
 
 // BlockContentCreateRequest represents the request body for blocking content.
 type BlockContentCreateRequest struct {
@@ -272,4 +273,15 @@ type BlockListFilter struct {
 	Action   string `json:"action,omitempty"`
 	Source   string `json:"source,omitempty"`
 	CaseID   *uint  `json:"case_id,omitempty"`
+}
+
+// SubjectBlockedResponse represents the response for checking if a subject is blocked.
+type SubjectBlockedResponse struct {
+	Blocked bool `json:"blocked"`
+}
+
+func (s *SubjectBlockedResponse) FromModel(model bool) error {
+	s.Blocked = model
+
+	return nil
 }

--- a/internal/db/crud.go
+++ b/internal/db/crud.go
@@ -157,6 +157,16 @@ func WithDBSelect(selectClause string) DBOption {
 	}
 }
 
+// WithDBJoin adds JOIN clauses to the query
+// joinType can be "JOIN", "LEFT JOIN", "RIGHT JOIN", etc.
+// table is the table to join
+// condition is the ON clause condition
+func WithDBJoin(joinType string, table string, condition string) DBOption {
+	return func(_db *gorm.DB) *gorm.DB {
+		return _db.Joins(fmt.Sprintf("%s %s ON %s", joinType, table, condition))
+	}
+}
+
 func ExecuteTransaction(ctx context.Context, coreCtx core.Context, _db *gorm.DB, operation string, txFunc TransactionFunc, fields ...zap.Field) error {
 	logger := coreCtx.Logger()
 
@@ -413,7 +423,7 @@ func ListIncludingSoftDeleted[T any](ctx context.Context, coreCtx core.Context, 
 // BulkCreate creates multiple records in the database.
 func BulkCreate[T any](ctx context.Context, coreCtx core.Context, _db *gorm.DB, records []T, options ...DBOption) error {
 	return ExecuteTransaction(ctx, coreCtx, _db, "BulkCreate", func(tx *gorm.DB) error {
-		_db = applyDbOptions(_db, options)
+		tx = applyDbOptions(tx, options)
 		return tx.CreateInBatches(records, 100).Error // Batch size of 100
 	})
 }
@@ -422,7 +432,7 @@ func BulkCreate[T any](ctx context.Context, coreCtx core.Context, _db *gorm.DB, 
 func BulkUpdate[T any](ctx context.Context, coreCtx core.Context, _db *gorm.DB, records []T, fields []string, options ...DBOption) error {
 	_db = applyDbOptions(_db, options)
 	return ExecuteTransaction(ctx, coreCtx, _db, "BulkUpdate", func(tx *gorm.DB) error {
-		_db = applyDbOptions(_db, options)
+		tx = applyDbOptions(tx, options)
 		return tx.Select(fields).Updates(records).Error
 	})
 }
@@ -431,7 +441,7 @@ func BulkUpdate[T any](ctx context.Context, coreCtx core.Context, _db *gorm.DB, 
 func Count[T any](ctx context.Context, coreCtx core.Context, _db *gorm.DB, filters []queryutil.CrudFilter, options ...DBOption) (int64, error) {
 	var count int64
 	err := ExecuteTransaction(ctx, coreCtx, _db, "Count", func(tx *gorm.DB) error {
-		_db = applyDbOptions(_db, options)
+		tx = applyDbOptions(tx, options)
 		tx = queryutil.ApplyFilters(tx, filters, nil)
 		return tx.Model(new(T)).Count(&count).Error
 	})

--- a/internal/service/blocklist.go
+++ b/internal/service/blocklist.go
@@ -222,6 +222,26 @@ func (s *BlockListServiceDefault) BatchBlockFromScanResults(ctx context.Context,
 	return blockedCount, nil
 }
 
+// IsSubjectBlocked checks if a subject ID is blocked
+func (s *BlockListServiceDefault) IsSubjectBlocked(subjectID uint) (bool, error) {
+	if subjectID == 0 {
+		return false, fmt.Errorf("invalid subjectID: cannot be zero")
+	}
+
+	count, err := db.Count[models.BlockList](context.Background(), s.ctx, s.db,
+		queryutil.Filters(queryutil.FieldEqual("abuse_subjects.id", subjectID)),
+		db.WithDBJoin("JOIN", "abuse_subjects", "abuse_blocklist.hash = abuse_subjects.identifier"))
+
+	if err != nil {
+		s.logger.Error("Failed to check subject block status",
+			zap.Error(err),
+			zap.Uint("subjectID", subjectID))
+		return false, fmt.Errorf("failed to check subject block status: %w", err)
+	}
+
+	return count > 0, nil
+}
+
 // GetBlockReasonCounts retrieves block reason counts within a time range.
 func (s *BlockListServiceDefault) GetBlockReasonCounts(filters []queryutil.CrudFilter) ([]typesSvc.BlockReasonCount, error) {
 	var counts []models.BlockReasonCount

--- a/internal/service/blocklist_test.go
+++ b/internal/service/blocklist_test.go
@@ -497,6 +497,79 @@ func TestBlockListService_GetBlocklistMetrics(t *testing.T) {
 	}, coreTesting.WithService(typesSvc.BLOCKLIST_SERVICE, NewBlockListService))
 }
 
+func TestBlockListService_IsSubjectBlocked_Blocked(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		blockListService := core.GetService[typesSvc.BlockListService](ctx, typesSvc.BLOCKLIST_SERVICE)
+		assert.NotNil(tb, blockListService)
+
+		// Create a test subject
+		subject := &models.Subject{
+			Identifier: []byte("testhash"),
+			Type:       models.SubjectTypeHash,
+		}
+		err := ctx.DB().Create(subject).Error
+		require.NoError(tb, err)
+
+		// Create a blocked content entry referencing the subject
+		blockedContent := &models.BlockList{
+			Hash:      []byte("testhash"),
+			Reason:    models.BlockReasonSpam,
+			Severity:  models.BlockSeverityHigh,
+			Action:    models.BlockActionReject,
+			BlockedBy: 1,
+			Source:    models.BlockSourceAdmin,
+		}
+		err = ctx.DB().Create(blockedContent).Error
+		require.NoError(tb, err)
+
+		// Act
+		isBlocked, err := blockListService.IsSubjectBlocked(subject.ID)
+
+		// Assert
+		assert.NoError(tb, err)
+		assert.True(tb, isBlocked)
+	}, coreTesting.WithService(typesSvc.BLOCKLIST_SERVICE, NewBlockListService))
+}
+
+func TestBlockListService_IsSubjectBlocked_NotBlocked(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		blockListService := core.GetService[typesSvc.BlockListService](ctx, typesSvc.BLOCKLIST_SERVICE)
+		assert.NotNil(tb, blockListService)
+
+		// Create a test subject
+		subject := &models.Subject{
+			Identifier: []byte("test-subject"),
+			Type:       models.SubjectTypeHash,
+		}
+		err := ctx.DB().Create(subject).Error
+		require.NoError(tb, err)
+
+		// Act
+		isBlocked, err := blockListService.IsSubjectBlocked(subject.ID)
+
+		// Assert
+		assert.NoError(tb, err)
+		assert.False(tb, isBlocked)
+	}, coreTesting.WithService(typesSvc.BLOCKLIST_SERVICE, NewBlockListService))
+}
+
+func TestBlockListService_IsSubjectBlocked_InvalidSubject(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		blockListService := core.GetService[typesSvc.BlockListService](ctx, typesSvc.BLOCKLIST_SERVICE)
+		assert.NotNil(tb, blockListService)
+
+		// Act
+		isBlocked, err := blockListService.IsSubjectBlocked(999999) // Non-existent subject ID
+
+		// Assert
+		assert.NoError(tb, err)
+		assert.False(tb, isBlocked)
+	}, coreTesting.WithService(typesSvc.BLOCKLIST_SERVICE, NewBlockListService))
+}
+
 func TestBlockListService_BatchBlockFromScanResults(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// Arrange

--- a/internal/service/mocks/BlockListService.go
+++ b/internal/service/mocks/BlockListService.go
@@ -554,6 +554,66 @@ func (_c *MockBlockListService_IsBlocked_Call) RunAndReturn(run func(hash core.S
 	return _c
 }
 
+// IsSubjectBlocked provides a mock function for the type MockBlockListService
+func (_mock *MockBlockListService) IsSubjectBlocked(subjectID uint) (bool, error) {
+	ret := _mock.Called(subjectID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsSubjectBlocked")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(uint) (bool, error)); ok {
+		return returnFunc(subjectID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(uint) bool); ok {
+		r0 = returnFunc(subjectID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(uint) error); ok {
+		r1 = returnFunc(subjectID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlockListService_IsSubjectBlocked_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsSubjectBlocked'
+type MockBlockListService_IsSubjectBlocked_Call struct {
+	*mock.Call
+}
+
+// IsSubjectBlocked is a helper method to define mock.On call
+//   - subjectID uint
+func (_e *MockBlockListService_Expecter) IsSubjectBlocked(subjectID interface{}) *MockBlockListService_IsSubjectBlocked_Call {
+	return &MockBlockListService_IsSubjectBlocked_Call{Call: _e.mock.On("IsSubjectBlocked", subjectID)}
+}
+
+func (_c *MockBlockListService_IsSubjectBlocked_Call) Run(run func(subjectID uint)) *MockBlockListService_IsSubjectBlocked_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 uint
+		if args[0] != nil {
+			arg0 = args[0].(uint)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlockListService_IsSubjectBlocked_Call) Return(b bool, err error) *MockBlockListService_IsSubjectBlocked_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockBlockListService_IsSubjectBlocked_Call) RunAndReturn(run func(subjectID uint) (bool, error)) *MockBlockListService_IsSubjectBlocked_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListBlockedContent provides a mock function for the type MockBlockListService
 func (_mock *MockBlockListService) ListBlockedContent(filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]models0.BlockList, int64, error) {
 	ret := _mock.Called(filters, sorts, pagination)

--- a/internal/types/service/blocklist_service.go
+++ b/internal/types/service/blocklist_service.go
@@ -47,6 +47,9 @@ type BlockListService interface {
 
 	// GetBlockReasonCounts retrieves block reason counts within a time range.
 	GetBlockReasonCounts(filters []queryutil.CrudFilter) ([]BlockReasonCount, error)
+
+	// IsSubjectBlocked checks if a subject ID is blocked
+	IsSubjectBlocked(subjectID uint) (bool, error)
 }
 
 // BlockReasonCount represents a single block reason count.


### PR DESCRIPTION
- Added new endpoint `/blocklist/subjects/:subject_id/blocked` to check if a subject is blocked
- Implemented service method `IsSubjectBlocked` with database query
- Added DTO `SubjectBlockedResponse` for the endpoint response
- Included comprehensive tests for the new functionality
- Added JOIN support in DB options for more complex queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin API endpoint to check if a subject is blocked, returning a clear blocked status.
* **Bug Fixes**
  * Improved transactional handling in bulk database operations to ensure options are applied correctly within transactions.
* **Tests**
  * Introduced comprehensive tests for the new blocklist status API and service logic, covering success, invalid input, and error scenarios.
* **Chores**
  * Expanded service interfaces and added mock methods to support the new blocklist status check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->