### PR TITLE
refactor(email): change URL subject processing and remove unused context parameter

### DIFF
--- a/internal/service/email.go
+++ b/internal/service/email.go
@@ -259,7 +259,7 @@ func (s *EmailServiceDefault) handleProcessedEmail(ctx context.Context, data io.
 	case result.Case != nil:
 		processErr = s.handleNewCase(result.Case, result.Email)
 	case result.ThreadMatch != nil:
-		processErr = s.handleThreadMatch(ctx, result.ThreadMatch, data)
+		processErr = s.handleThreadMatch(result.ThreadMatch, data)
 	default:
 		processErr = fmt.Errorf("unknown email processing result type")
 	}
@@ -300,18 +300,23 @@ func (s *EmailServiceDefault) handleARFReport(arfData *email.ARFReport, caseMode
 		return err
 	}
 
-	// Extract subjects first
+	// Extract hashes first - we require at least one valid hash
+	hashSubjectIDs, err := s.extractAndLinkHashSubjects(arfData.FeedbackText)
+	if err != nil {
+		return fmt.Errorf("error extracting hash subjects: %w", err)
+	}
+	if len(hashSubjectIDs) == 0 {
+		s.logger.Info("Skipping ARF report - no valid hashes found")
+		return nil
+	}
+
+	// Extract URLs if available (optional)
 	urlSubjectIDs, err := s.extractAndLinkURLSubjects(arfData.FeedbackText)
 	if err != nil {
 		return fmt.Errorf("error extracting URL subjects: %w", err)
 	}
 
-	hashSubjectIDs, err := s.extractAndLinkHashSubjects(arfData.FeedbackText)
-	if err != nil {
-		return fmt.Errorf("error extracting hash subjects: %w", err)
-	}
-
-	allSubjectIDs := append(urlSubjectIDs, hashSubjectIDs...)
+	allSubjectIDs := lo.Uniq(append(hashSubjectIDs, urlSubjectIDs...))
 
 	// Check reporter trust status once before the loop
 	isTrusted, err := s.reporterSvc.IsTrusted(reporter)
@@ -410,18 +415,24 @@ func (s *EmailServiceDefault) handleNewCase(caseModel *models.Case, email *lette
 		}
 	}
 
-	// Extract subjects first
+	// Extract hashes first - we require at least one valid hash
+	hashSubjectIDs, err := s.extractAndLinkHashSubjects(email.Text)
+	if err != nil {
+		return fmt.Errorf("error extracting hash subjects: %w", err)
+	}
+	if len(hashSubjectIDs) == 0 {
+		s.logger.Info("Skipping email - no valid hashes found")
+		return nil
+	}
+
+	// Extract URLs if available (optional)
 	urlSubjectIDs, err := s.extractAndLinkURLSubjects(email.Text)
 	if err != nil {
 		return fmt.Errorf("error extracting URL subjects: %w", err)
 	}
 
-	hashSubjectIDs, err := s.extractAndLinkHashSubjects(email.Text)
-	if err != nil {
-		return fmt.Errorf("error extracting hash subjects: %w", err)
-	}
-
-	allSubjectIDs := append(urlSubjectIDs, hashSubjectIDs...)
+	allSubjectIDs := append(hashSubjectIDs, urlSubjectIDs...)
+	allSubjectIDs = lo.Uniq(allSubjectIDs)
 
 	// Create cases for each subject
 	for _, subjectID := range allSubjectIDs {
@@ -483,21 +494,21 @@ func (s *EmailServiceDefault) ProcessIncomingEmail(ctx context.Context, rawEmail
 }
 
 // handleThreadMatch adds communication to an existing case
-func (s *EmailServiceDefault) handleThreadMatch(ctx context.Context, match *email.ThreadMatch, rawEmail io.Reader) error {
+func (s *EmailServiceDefault) handleThreadMatch(match *email.ThreadMatch, rawEmail io.Reader) error {
 	if s.commSvc == nil {
 		return fmt.Errorf("communication service not available")
 	}
 
 	// Parse the email content
-	email, err := letters.ParseEmail(rawEmail)
+	_email, err := letters.ParseEmail(rawEmail)
 	if err != nil {
 		return fmt.Errorf("failed to parse email: %w", err)
 	}
 
 	// Get email content
-	content := email.Text
+	content := _email.Text
 	if content == "" {
-		content = email.HTML
+		content = _email.HTML
 	}
 
 	// Create communication record
@@ -527,7 +538,7 @@ func (s *EmailServiceDefault) handleThreadMatch(ctx context.Context, match *emai
 	}
 
 	// Extract subject from email headers
-	subject := email.Headers.Subject
+	subject := _email.Headers.Subject
 	if subject == "" {
 		subject = "(no subject)"
 	}
@@ -667,7 +678,7 @@ func (s *EmailServiceDefault) hashEmailContent(email *letters.Email) ([]byte, er
 	return hash[:], nil
 }
 
-// extractAndLinkURLSubjects extracts URLs from email content and links them to case
+// extractAndLinkURLSubjects extracts hashes from URLs in email content and links them to case
 func (s *EmailServiceDefault) extractAndLinkURLSubjects(emailContent string) ([]uint, error) {
 	if s.subjectSvc == nil {
 		s.logger.Error("Subject service not available")
@@ -686,14 +697,39 @@ func (s *EmailServiceDefault) extractAndLinkURLSubjects(emailContent string) ([]
 	subjectIDs := make([]uint, 0, len(urls)) // Pre-allocate slice
 
 	for _, url := range urls {
-		subject, err := s.subjectSvc.FindOrCreateByURL(url, models.SubjectTypeURL)
-		if err != nil {
-			s.logger.Error("Failed to create subject from URL",
-				zap.Error(err),
-				zap.String("url", url))
-			return nil, fmt.Errorf("failed to create subject from URL: %w", err)
+		feedbackEmail = &letters.Email{
+			Text: url,
 		}
-		subjectIDs = append(subjectIDs, subject.ID)
+		// Try to extract hashes from URL path
+		hashes := contentExtractor.ExtractHashes(feedbackEmail)
+		if len(hashes) == 0 {
+			s.logger.Debug("No hashes found in URL",
+				zap.String("url", url))
+			continue
+		}
+
+		// Process each found hash
+		for _, hash := range hashes {
+			// Create subject for the hash if found
+			sHash, err := core.ParseStorageHash(hash)
+			if err != nil {
+				s.logger.Warn("Failed to parse hash from URL",
+					zap.String("url", url),
+					zap.String("hash", hash),
+					zap.Error(err))
+				continue
+			}
+
+			hashSubject, err := s.subjectSvc.FindOrCreate(sHash, models.SubjectTypeHash, url)
+			if err != nil {
+				s.logger.Error("Failed to create subject from hash in URL",
+					zap.String("url", url),
+					zap.String("hash", hash),
+					zap.Error(err))
+				continue
+			}
+			subjectIDs = append(subjectIDs, hashSubject.ID)
+		}
 	}
 
 	return subjectIDs, nil
@@ -726,7 +762,7 @@ func (s *EmailServiceDefault) extractAndLinkHashSubjects(emailContent string) ([
 			return nil, fmt.Errorf("failed to parse hash: %w", err)
 		}
 
-		subject, err := s.subjectSvc.FindOrCreate(sHash, models.SubjectTypeHash)
+		subject, err := s.subjectSvc.FindOrCreate(sHash, models.SubjectTypeHash, "")
 		if err != nil {
 			s.logger.Error("Failed to create subject from hash",
 				zap.Error(err),

--- a/internal/service/mocks/SubjectService.go
+++ b/internal/service/mocks/SubjectService.go
@@ -101,8 +101,8 @@ func (_c *MockSubjectService_Create_Call) RunAndReturn(run func(subject *models.
 }
 
 // FindOrCreate provides a mock function for the type MockSubjectService
-func (_mock *MockSubjectService) FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType) (*models.Subject, error) {
-	ret := _mock.Called(identifier, subjectType)
+func (_mock *MockSubjectService) FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType, url string) (*models.Subject, error) {
+	ret := _mock.Called(identifier, subjectType, url)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindOrCreate")
@@ -110,18 +110,18 @@ func (_mock *MockSubjectService) FindOrCreate(identifier core.StorageHash, subje
 
 	var r0 *models.Subject
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(core.StorageHash, models.SubjectType) (*models.Subject, error)); ok {
-		return returnFunc(identifier, subjectType)
+	if returnFunc, ok := ret.Get(0).(func(core.StorageHash, models.SubjectType, string) (*models.Subject, error)); ok {
+		return returnFunc(identifier, subjectType, url)
 	}
-	if returnFunc, ok := ret.Get(0).(func(core.StorageHash, models.SubjectType) *models.Subject); ok {
-		r0 = returnFunc(identifier, subjectType)
+	if returnFunc, ok := ret.Get(0).(func(core.StorageHash, models.SubjectType, string) *models.Subject); ok {
+		r0 = returnFunc(identifier, subjectType, url)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Subject)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(core.StorageHash, models.SubjectType) error); ok {
-		r1 = returnFunc(identifier, subjectType)
+	if returnFunc, ok := ret.Get(1).(func(core.StorageHash, models.SubjectType, string) error); ok {
+		r1 = returnFunc(identifier, subjectType, url)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -136,11 +136,12 @@ type MockSubjectService_FindOrCreate_Call struct {
 // FindOrCreate is a helper method to define mock.On call
 //   - identifier core.StorageHash
 //   - subjectType models.SubjectType
-func (_e *MockSubjectService_Expecter) FindOrCreate(identifier interface{}, subjectType interface{}) *MockSubjectService_FindOrCreate_Call {
-	return &MockSubjectService_FindOrCreate_Call{Call: _e.mock.On("FindOrCreate", identifier, subjectType)}
+//   - url string
+func (_e *MockSubjectService_Expecter) FindOrCreate(identifier interface{}, subjectType interface{}, url interface{}) *MockSubjectService_FindOrCreate_Call {
+	return &MockSubjectService_FindOrCreate_Call{Call: _e.mock.On("FindOrCreate", identifier, subjectType, url)}
 }
 
-func (_c *MockSubjectService_FindOrCreate_Call) Run(run func(identifier core.StorageHash, subjectType models.SubjectType)) *MockSubjectService_FindOrCreate_Call {
+func (_c *MockSubjectService_FindOrCreate_Call) Run(run func(identifier core.StorageHash, subjectType models.SubjectType, url string)) *MockSubjectService_FindOrCreate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 core.StorageHash
 		if args[0] != nil {
@@ -150,9 +151,14 @@ func (_c *MockSubjectService_FindOrCreate_Call) Run(run func(identifier core.Sto
 		if args[1] != nil {
 			arg1 = args[1].(models.SubjectType)
 		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -163,7 +169,7 @@ func (_c *MockSubjectService_FindOrCreate_Call) Return(subject *models.Subject, 
 	return _c
 }
 
-func (_c *MockSubjectService_FindOrCreate_Call) RunAndReturn(run func(identifier core.StorageHash, subjectType models.SubjectType) (*models.Subject, error)) *MockSubjectService_FindOrCreate_Call {
+func (_c *MockSubjectService_FindOrCreate_Call) RunAndReturn(run func(identifier core.StorageHash, subjectType models.SubjectType, url string) (*models.Subject, error)) *MockSubjectService_FindOrCreate_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/service/subject.go
+++ b/internal/service/subject.go
@@ -60,7 +60,7 @@ func (s *SubjectServiceDefault) GetByID(id uint) (*models.Subject, error) {
 }
 
 // FindOrCreate finds an existing subject or creates a new one
-func (s *SubjectServiceDefault) FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType) (*models.Subject, error) {
+func (s *SubjectServiceDefault) FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType, sourceUrl string) (*models.Subject, error) {
 	var subject models.Subject
 	properties := map[string]any{
 		"identifier": identifier.Multihash(),
@@ -74,6 +74,7 @@ func (s *SubjectServiceDefault) FindOrCreate(identifier core.StorageHash, subjec
 			subject = models.Subject{
 				Identifier: identifier.Multihash(),
 				Type:       subjectType,
+				SourceURL:  sourceUrl,
 			}
 			if err := db.Create(context.Background(), s.ctx, s.db, &subject); err != nil {
 				s.logger.Error("Failed to create subject", zap.Error(err), zap.Stringer("identifier", identifier), zap.String("type", string(subjectType)))

--- a/internal/service/subject_test.go
+++ b/internal/service/subject_test.go
@@ -119,7 +119,7 @@ func TestSubjectService_FindOrCreate_Existing(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Act
-		retrievedSubject, err := subjectService.FindOrCreate(core.NewStorageHashFromRawMultihash(mh), subjectType)
+		retrievedSubject, err := subjectService.FindOrCreate(core.NewStorageHashFromRawMultihash(mh), subjectType, "")
 
 		// Assert
 		require.NoError(tb, err)
@@ -146,7 +146,7 @@ func TestSubjectService_FindOrCreate_New(t *testing.T) {
 		subjectType := models.SubjectTypeHash
 
 		// Act
-		createdSubject, err := subjectService.FindOrCreate(_hash, subjectType)
+		createdSubject, err := subjectService.FindOrCreate(_hash, subjectType, "")
 
 		// Assert
 		require.NoError(tb, err)

--- a/internal/types/service/subject_service.go
+++ b/internal/types/service/subject_service.go
@@ -17,7 +17,7 @@ type SubjectService interface {
 	GetByID(id uint) (*models.Subject, error)
 
 	// FindOrCreate finds an existing subject or creates a new one
-	FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType) (*models.Subject, error)
+	FindOrCreate(identifier core.StorageHash, subjectType models.SubjectType, url string) (*models.Subject, error)
 
 	// FindOrCreateByURL finds an existing subject by URL or creates a new one
 	FindOrCreateByURL(url string, subjectType models.SubjectType) (*models.Subject, error)


### PR DESCRIPTION
- Modified `handleThreadMatch` to remove unused context parameter
- Updated `FindOrCreate` method to accept source URL parameter
- Improved URL subject processing to extract hashes from URLs
- Added deduplication of subject IDs using `lo.Uniq`
- Updated mock and test files to match interface changes
- Skip email processing when no valid hashes found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of email and report processing by requiring valid hash subjects before proceeding, with enhanced logging for skipped items.
  * Enhanced subject extraction from URLs by focusing on hashes within URLs and skipping those without valid hashes.

* **Refactor**
  * Updated subject creation logic to include source URL information, providing more context for newly created subjects.
  * Streamlined method signatures and parameter usage for clarity and consistency across subject-related operations.

* **Tests**
  * Adjusted test cases to accommodate updated subject creation method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->