### PR TITLE
feat(email): add connection recovery and keepalive

### DIFF
--- a/internal/pkg/email/imap_client.go
+++ b/internal/pkg/email/imap_client.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"fmt"
+	"github.com/emersion/go-imap/client"
 	"sync"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
+
+var ErrNotLoggedIn = client.ErrNotLoggedIn
 
 // IMAPClient defines the interface for IMAP clients
 type IMAPClient interface {
@@ -122,6 +125,27 @@ func (c *IMAPClientDefault) Stop() error {
 	return nil
 }
 
+// reconnect establishes a new connection to the IMAP server
+func (c *IMAPClientDefault) reconnect() error {
+	if c.client != nil {
+		_ = c.client.Logout() // Best effort logout
+	}
+
+	addr := fmt.Sprintf("%s:%d", c.config.IMAPHost, c.config.IMAPPort)
+	imapClient, err := c.dialer.DialTLS(addr, nil)
+	if err != nil {
+		return fmt.Errorf("failed to reconnect to IMAP server: %w", err)
+	}
+
+	if err := imapClient.Login(c.config.IMAPUser, c.config.IMAPPassword); err != nil {
+		return fmt.Errorf("failed to relogin to IMAP server: %w", err)
+	}
+
+	c.client = imapClient
+	c.logger.Info("Successfully reconnected to IMAP server")
+	return nil
+}
+
 // pollForEmails polls the IMAP server for new emails at regular intervals
 func (c *IMAPClientDefault) pollForEmails() {
 	defer c.waitGroup.Done()
@@ -138,6 +162,15 @@ func (c *IMAPClientDefault) pollForEmails() {
 			return
 		case <-ticker.C:
 			c.checkForNewEmails()
+		case <-time.After(5 * time.Minute): // Send NOOP every 5 minutes
+			if c.client != nil {
+				if err := c.client.Noop(); err != nil {
+					c.logger.Warn("IMAP connection appears dead, will reconnect", zap.Error(err))
+					if err := c.reconnect(); err != nil {
+						c.logger.Error("Failed to reconnect", zap.Error(err))
+					}
+				}
+			}
 		}
 	}
 }
@@ -156,8 +189,22 @@ func (c *IMAPClientDefault) checkForNewEmails() {
 
 	mbox, err := c.client.Select(mailbox, false)
 	if err != nil {
-		c.logger.Error("Failed to select mailbox", zap.String("mailbox", mailbox), zap.Error(err))
-		return
+		if err == ErrNotLoggedIn {
+			c.logger.Warn("Session expired, attempting to reconnect...", zap.String("mailbox", mailbox))
+			if err := c.reconnect(); err != nil {
+				c.logger.Error("Failed to reconnect", zap.Error(err))
+				return
+			}
+			// Retry after reconnecting
+			mbox, err = c.client.Select(mailbox, false)
+			if err != nil {
+				c.logger.Error("Failed to select mailbox after reconnect", zap.String("mailbox", mailbox), zap.Error(err))
+				return
+			}
+		} else {
+			c.logger.Error("Failed to select mailbox", zap.String("mailbox", mailbox), zap.Error(err))
+			return
+		}
 	}
 
 	if mbox.Messages == 0 {

--- a/internal/pkg/email/imap_client_interfaces.go
+++ b/internal/pkg/email/imap_client_interfaces.go
@@ -29,6 +29,9 @@ type IMAPClientConn interface {
 
 	// Store updates message flags
 	Store(seqSet *imap.SeqSet, item imap.StoreItem, flags []interface{}, ch chan *imap.Message) error
+	
+	// Noop sends a NOOP command to keep the connection alive
+	Noop() error
 }
 
 // IMAPDialer defines the interface for connecting to an IMAP server
@@ -88,6 +91,11 @@ func (a *IMAPClientAdapter) Fetch(seqSet *imap.SeqSet, items []imap.FetchItem, c
 // Store implements IMAPClientConn
 func (a *IMAPClientAdapter) Store(seqSet *imap.SeqSet, item imap.StoreItem, flags []interface{}, ch chan *imap.Message) error {
 	return a.client.Store(seqSet, item, flags, ch)
+}
+
+// Noop implements IMAPClientConn
+func (a *IMAPClientAdapter) Noop() error {
+	return a.client.Noop()
 }
 
 // Package level variable for our IMAP dialer, which can be replaced in tests

--- a/internal/pkg/email/mock_IMAPClientConn.go
+++ b/internal/pkg/email/mock_IMAPClientConn.go
@@ -200,6 +200,50 @@ func (_c *MockIMAPClientConn_Logout_Call) RunAndReturn(run func() error) *MockIM
 	return _c
 }
 
+// Noop provides a mock function for the type MockIMAPClientConn
+func (_mock *MockIMAPClientConn) Noop() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Noop")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockIMAPClientConn_Noop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Noop'
+type MockIMAPClientConn_Noop_Call struct {
+	*mock.Call
+}
+
+// Noop is a helper method to define mock.On call
+func (_e *MockIMAPClientConn_Expecter) Noop() *MockIMAPClientConn_Noop_Call {
+	return &MockIMAPClientConn_Noop_Call{Call: _e.mock.On("Noop")}
+}
+
+func (_c *MockIMAPClientConn_Noop_Call) Run(run func()) *MockIMAPClientConn_Noop_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIMAPClientConn_Noop_Call) Return(err error) *MockIMAPClientConn_Noop_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockIMAPClientConn_Noop_Call) RunAndReturn(run func() error) *MockIMAPClientConn_Noop_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Search provides a mock function for the type MockIMAPClientConn
 func (_mock *MockIMAPClientConn) Search(criteria *imap.SearchCriteria) ([]uint32, error) {
 	ret := _mock.Called(criteria)


### PR DESCRIPTION
- Added reconnect logic when IMAP session expires
- Implemented periodic NOOP commands to keep connection alive
- Added ErrNotLoggedIn error handling
- Extended IMAPClientConn interface with Noop() method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved email connection reliability by automatically reconnecting if the session expires or the connection is lost.
  * Enhanced connection stability by periodically sending keep-alive commands to the email server.

* **Bug Fixes**
  * Improved error handling when the email session expires, ensuring automatic recovery and reduced downtime.

* **Tests**
  * Added new test capabilities to simulate and verify keep-alive and reconnection behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->