### PR TITLE
fix(api): change case update endpoint from PUT to PATCH method

### DIFF
--- a/internal/api/admin_extension_case.go
+++ b/internal/api/admin_extension_case.go
@@ -85,7 +85,7 @@ func (e *AdminExtension) registerCaseHandlers(gRouter router.Router, accessSvc c
 		),
 
 		// Update Case
-		router.NewRoute(http.MethodPut, "/cases/:id", e.updateCase,
+		router.NewRoute(http.MethodPatch, "/cases/:id", e.updateCase,
 			router.WithAccess(core.ACCESS_ADMIN_ROLE),
 			router.WithSwagger(
 				router.WithSummary("Update Case"),

--- a/internal/api/admin_extension_case_test.go
+++ b/internal/api/admin_extension_case_test.go
@@ -192,7 +192,7 @@ func TestUpdateCase_Success(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Act
-		req := ctx.NewAPIRequest(http.MethodPut, "/api/abuse/cases/1", body)
+		req := ctx.NewAPIRequest(http.MethodPatch, "/api/abuse/cases/1", body)
 		require.NotNil(tb, req)
 		w := httptest.NewRecorder()
 		ctx.Router().ServeHTTP(w, req)
@@ -216,7 +216,7 @@ func TestUpdateCase_NotFound(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Act
-		req := ctx.NewAPIRequest(http.MethodPut, "/api/abuse/cases/999", body)
+		req := ctx.NewAPIRequest(http.MethodPatch, "/api/abuse/cases/999", body)
 		require.NotNil(tb, req)
 		w := httptest.NewRecorder()
 		ctx.Router().ServeHTTP(w, req)


### PR DESCRIPTION
- Updated HTTP method for case update endpoint from PUT to PATCH in route registration
- Modified corresponding test cases to use PATCH method instead of PUT