### PR TITLE
refactor(dto): update schema definitions and type usage

### DIFF
--- a/internal/api/admin_extension_case_test.go
+++ b/internal/api/admin_extension_case_test.go
@@ -183,8 +183,8 @@ func TestUpdateCase_Success(t *testing.T) {
 
 		reqBody := dto.UpdateCaseRequest{
 			Description: lo.ToPtr("Updated description"),
-			Type:        lo.ToPtr(string(models.CaseTypeSpam)),
-			Priority:    lo.ToPtr(string(models.CasePriorityHigh)),
+			Type:        lo.ToPtr(models.CaseTypeSpam),
+			Priority:    lo.ToPtr(models.CasePriorityHigh),
 			ReporterID:  lo.ToPtr(1),
 			SubjectID:   lo.ToPtr(1),
 		}

--- a/internal/api/dto/abuse_report.go
+++ b/internal/api/dto/abuse_report.go
@@ -18,11 +18,11 @@ var dtoLogger = core.NewLogger(nil)
 
 // AbuseReportRequest represents the incoming request for an abuse report
 type AbuseReportRequest struct {
-	Email             string `json:"email"`
-	Location          string `json:"location"`
-	AbuseType         string `json:"abuse_type"`
-	Description       string `json:"description"`
-	AdditionalDetails string `json:"additional_details,omitempty"`
+	Email             string          `json:"email"`
+	Location          string          `json:"location"`
+	AbuseType         models.CaseType `json:"abuse_type"`
+	Description       string          `json:"description"`
+	AdditionalDetails string          `json:"additional_details,omitempty"`
 }
 
 // ToCaseModel converts the DTO to a Case model
@@ -44,7 +44,7 @@ func (r AbuseReportRequest) ToModel() (*models.Case, error) {
 	}
 
 	caseModel := &models.Case{
-		Type:        models.CaseType(r.AbuseType),
+		Type:        r.AbuseType,
 		Status:      models.CaseStatusNew,
 		Priority:    models.CasePriorityMedium,
 		Description: r.Description,
@@ -64,7 +64,7 @@ func (r AbuseReportRequest) ToModel() (*models.Case, error) {
 }
 
 func (r *AbuseReportRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Email":             z.String().Required().Email(),
 		"Location":          z.String().Required().URL(),
 		"AbuseType":         z.StringLike[models.CaseType]().Required().OneOf(models.ValidCaseTypes),

--- a/internal/api/dto/blocklist.go
+++ b/internal/api/dto/blocklist.go
@@ -119,7 +119,7 @@ func (r *BlockContentUpdateRequest) ToModel() (*models.BlockList, error) {
 }
 
 func (r *BlockContentCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Hash":       z.String().Required(),
 		"MimeType":   z.String().Optional(),
 		"FileName":   z.String().Optional(),
@@ -161,7 +161,7 @@ func (r *BlockContentCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *BlockContentUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"MimeType":   z.Ptr(z.String().Optional()),
 		"FileName":   z.Ptr(z.String().Optional()),
 		"Size":       z.Ptr(z.Int64().Optional()),

--- a/internal/api/dto/case.go
+++ b/internal/api/dto/case.go
@@ -177,7 +177,7 @@ func (r *CaseStatusUpdateRequest) ToModel() (*models.Case, error) {
 }
 
 func (r *CaseStatusUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Status": z.String().Required().OneOf([]string{
 			string(models.CaseStatusNew),
 			string(models.CaseStatusInProgress),

--- a/internal/api/dto/communication.go
+++ b/internal/api/dto/communication.go
@@ -31,7 +31,7 @@ type CommunicationUpdateRequest struct {
 }
 
 func (r *CommunicationCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Content": z.String().Required().Min(1),
 		"Type": z.String().Required().OneOf([]string{
 			string(models.CommunicationTypeEmail),
@@ -49,7 +49,7 @@ func (r *CommunicationCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *CommunicationUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Content": z.Ptr(z.String().Optional().Min(1)),
 		"Type": z.Ptr(z.String().Optional().OneOf([]string{
 			string(models.CommunicationTypeEmail),

--- a/internal/api/dto/evidence.go
+++ b/internal/api/dto/evidence.go
@@ -50,7 +50,7 @@ type EvidenceResponse struct {
 }
 
 func (r *EvidenceCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"FileName":    z.String().Required(),
 		"ContentType": z.String().Required(),
 		"Source": z.String().Required().OneOf([]string{
@@ -64,7 +64,7 @@ func (r *EvidenceCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *EvidenceUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"FileName":    z.Ptr(z.String().Optional()),
 		"ContentType": z.Ptr(z.String().Optional()),
 		"Source": z.Ptr(z.String().Optional().OneOf([]string{

--- a/internal/api/dto/provider_template.go
+++ b/internal/api/dto/provider_template.go
@@ -33,10 +33,10 @@ type ProviderTemplateUpdateRequest struct {
 }
 
 func (r *ProviderTemplateCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
-		"Name":             z.String().Required().Min(2),
-		"Enabled":          z.Bool().Optional().Default(true),
-		"Priority":         z.Int().Optional().Default(100).GT(0),
+	return z.Struct(z.Shape{
+		"Name":            z.String().Required().Min(2),
+		"Enabled":         z.Bool().Optional().Default(true),
+		"Priority":        z.Int().Optional().Default(100).GT(0),
 		"DomainPatterns":  z.Slice(z.String().Required().Min(1)),
 		"HeaderPatterns":  z.Slice(z.String()),
 		"ContentPatterns": z.Slice(z.String()),
@@ -44,12 +44,12 @@ func (r *ProviderTemplateCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *ProviderTemplateUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Name":            z.Ptr(z.String().Optional().Min(2)),
 		"Enabled":         z.Ptr(z.Bool().Optional()),
 		"Priority":        z.Ptr(z.Int().Optional().GT(0)),
-		"DomainPatterns": z.Ptr(z.Slice(z.String().Required().Min(1))),
-		"HeaderPatterns": z.Ptr(z.Slice(z.String())),
+		"DomainPatterns":  z.Ptr(z.Slice(z.String().Required().Min(1))),
+		"HeaderPatterns":  z.Ptr(z.Slice(z.String())),
 		"ContentPatterns": z.Ptr(z.Slice(z.String())),
 	})
 }
@@ -77,7 +77,7 @@ func (r *ProviderTemplateCreateRequest) ToModel() (*config.ProviderTemplateConfi
 
 func (r *ProviderTemplateUpdateRequest) ToModel() (*config.ProviderTemplateConfig, error) {
 	cfg := &config.ProviderTemplateConfig{}
-	
+
 	if r.Name != nil {
 		cfg.Name = *r.Name
 	}
@@ -96,7 +96,7 @@ func (r *ProviderTemplateUpdateRequest) ToModel() (*config.ProviderTemplateConfi
 	if r.ContentPatterns != nil {
 		cfg.ContentPatterns = *r.ContentPatterns
 	}
-	
+
 	return cfg, nil
 }
 

--- a/internal/api/dto/reporter.go
+++ b/internal/api/dto/reporter.go
@@ -26,14 +26,14 @@ type ReporterUpdateRequest struct {
 }
 
 func (r *ReporterCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Email": z.String().Required().Email(),
 		"Name":  z.String().Required().Min(2),
 	})
 }
 
 func (r *ReporterUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Email": z.Ptr(z.String().Optional().Email()),
 		"Name":  z.Ptr(z.String().Optional().Min(2)),
 	})

--- a/internal/api/dto/scan.go
+++ b/internal/api/dto/scan.go
@@ -78,7 +78,7 @@ func (r *ManualScanRequest) ToModel() (*models.CaseScan, error) {
 }
 
 func (r *ManualScanRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"CaseID": z.Int().Required().GT(0),
 	})
 }

--- a/internal/api/dto/subject.go
+++ b/internal/api/dto/subject.go
@@ -28,7 +28,7 @@ type SubjectUpdateRequest struct {
 }
 
 func (r *SubjectCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Identifier": z.String().Required().Min(3),
 		"Type": z.String().Required().OneOf([]string{
 			string(models.SubjectTypeHash),
@@ -38,7 +38,7 @@ func (r *SubjectCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *SubjectUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Identifier": z.Ptr(z.String().Optional().Min(3)),
 		"Type": z.Ptr(z.String().Optional().OneOf([]string{
 			string(models.SubjectTypeHash),

--- a/internal/api/dto/token.go
+++ b/internal/api/dto/token.go
@@ -52,7 +52,7 @@ type TokenRefreshRequest struct {
 }
 
 func (r *TokenRefreshRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Token": z.String().Required(),
 	})
 }
@@ -65,7 +65,7 @@ func (req *TokenRefreshRequest) ToModel() (*models.Token, error) {
 }
 
 func (r *TokenCreateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"CaseID":     z.Int().Required().GT(0),
 		"ReporterID": z.Int().Required().GT(0),
 		"ValidDays":  z.Int().GT(1).LTE(365),
@@ -73,7 +73,7 @@ func (r *TokenCreateRequest) Schema() *z.StructSchema {
 }
 
 func (r *TokenUpdateRequest) Schema() *z.StructSchema {
-	return z.Struct(z.Schema{
+	return z.Struct(z.Shape{
 		"Revoke": z.Ptr(z.Bool().Optional()),
 	})
 }


### PR DESCRIPTION
- Changed z.Schema to z.Shape in all DTO schema definitions
- Updated AbuseReportRequest to use models.CaseType directly instead of string
- Fixed type casting in UpdateCaseRequest test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal schema validation by updating schema construction methods for various request types, enhancing type safety and maintainability. No changes to validation rules or user-facing fields.
  * Strengthened type enforcement for abuse report types, ensuring more consistent handling of case types across the application.

* **Tests**
  * Updated test cases to align with improved type safety and schema validation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->