### PR TITLE
fix(case): Correctly map case data and update notification templates

### DIFF
--- a/internal/api/dto/case.go
+++ b/internal/api/dto/case.go
@@ -211,6 +211,7 @@ func (r *CaseResponse) FromModel(c *models.Case) error {
 	r.CreatedAt = c.CreatedAt
 	r.UpdatedAt = c.UpdatedAt
 	r.ReferenceNumber = "CASE-" + c.ReferenceNumber // Ensure consistent prefix
+	r.Description = c.Description
 	r.Type = string(c.Type)
 	r.Status = string(c.Status)
 	r.Priority = string(c.Priority)
@@ -224,10 +225,10 @@ func (r *CaseResponse) FromModel(c *models.Case) error {
 // ToModel converts a create request DTO to a model
 func (req *CreateCaseRequest) ToModel() (*models.Case, error) {
 	caseModel := &models.Case{
-		Type:        models.CaseType(req.Type),
+		Type:        req.Type,
 		Description: req.Description,
-		Priority:    models.CasePriority(req.Priority),
-		Source:      models.ReportSource(req.Source),
+		Priority:    req.Priority,
+		Source:      req.Source,
 		NeedsReview: req.NeedsReview,
 		ReporterID:  uint(req.ReporterID),
 		SubjectID:   uint(req.SubjectID),

--- a/internal/service/case.go
+++ b/internal/service/case.go
@@ -215,15 +215,15 @@ func (s *CaseServiceDefault) SendStatusUpdateNotification(caseID uint, oldStatus
 	siteURL := core.GetService[core.HTTPService](s.ctx, core.HTTP_SERVICE).APISubdomain("admin", true)
 
 	templateData := core.MailerTemplateData{
-		"Reference":   caseModel.ReferenceNumber,
-		"OldStatus":   oldStatus,
-		"NewStatus":   newStatus,
-		"CaseType":    caseModel.Type,
-		"PortalName":  s.ctx.Config().Config().Core.PortalName,
-		"UpdatedDate": time.Now().Format("January 2, 2006 15:04"),
-		"CreatedDate": caseModel.CreatedAt.Format("January 2, 2006 15:04"),
-		"DetailsURL":  fmt.Sprintf("%s/case/%s", siteURL, caseModel.ReferenceNumber),
-		"ReplyTo":     threadID,
+		"ReferenceNumber": caseModel.ReferenceNumber,
+		"OldStatus":       oldStatus,
+		"NewStatus":       newStatus,
+		"CaseType":        caseModel.Type,
+		"PortalName":      s.ctx.Config().Config().Core.PortalName,
+		"UpdatedDate":     time.Now().Format("January 2, 2006 15:04"),
+		"CreatedDate":     caseModel.CreatedAt.Format("January 2, 2006 15:04"),
+		"DetailsURL":      fmt.Sprintf("%s/case/%s", siteURL, caseModel.ReferenceNumber),
+		"ReplyTo":         threadID,
 	}
 
 	err = s.emailSvc.SendTemplatedEmail(


### PR DESCRIPTION
- Correctly map the description field from the model to the DTO in `CaseResponse`.
- Update the `case_status_updated` notification template to use `ReferenceNumber` instead of `Reference`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that case descriptions are now included in responses.
  * Improved consistency in how case type, priority, and source are handled when creating new cases.

* **Refactor**
  * Updated notification templates to use "ReferenceNumber" instead of "Reference" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->